### PR TITLE
remove trailing comma for valid json formatting

### DIFF
--- a/smartapps/thefuzz4/splunk-http-event-logger.src/splunk-http-event-logger.groovy
+++ b/smartapps/thefuzz4/splunk-http-event-logger.src/splunk-http-event-logger.groovy
@@ -191,7 +191,7 @@ json += "\"isPhysical\":\"${evt.isPhysical()}\","
 json += "\"location\":\"${evt.location}\","
 json += "\"locationId\":\"${evt.locationId}\","
 json += "\"unit\":\"${evt.unit}\","
-json += "\"source\":\"${evt.source}\",}"
+json += "\"source\":\"${evt.source}\"}"
 json += "}"
 //log.debug("JSON: ${json}")
 def ssl = use_ssl.toBoolean()


### PR DESCRIPTION
noticed the splunk wasn't recognizing the message as valid json. removed the final comma in the json string and verified that splunk recognizes as valid json.