### PR TITLE
Removing trailing comma

### DIFF
--- a/smartapps/thefuzz4/splunk-http-event-logger.src/splunk-http-event-logger.groovy
+++ b/smartapps/thefuzz4/splunk-http-event-logger.src/splunk-http-event-logger.groovy
@@ -191,7 +191,7 @@ json += "\"isPhysical\":\"${evt.isPhysical()}\","
 json += "\"location\":\"${evt.location}\","
 json += "\"locationId\":\"${evt.locationId}\","
 json += "\"unit\":\"${evt.unit}\","
-json += "\"source\":\"${evt.source}\",}"
+json += "\"source\":\"${evt.source}\"}"
 json += "}"
 //log.debug("JSON: ${json}")
 def ssl = use_ssl.toBoolean()


### PR DESCRIPTION
There was a trailing comma in the JSON payload right before the closing brace which caused Splunk's JSON pretty printer to choke. Quick one-byte fix.